### PR TITLE
fix: `init` command fail if no github accounts are added

### DIFF
--- a/src/create_github_project/cli.py
+++ b/src/create_github_project/cli.py
@@ -135,21 +135,21 @@ def parse_reviewer(reviewers: str, key: str, question: str) -> Dict[str, Dict[st
     return {aid: accounts.get_account_info(aid) for aid in account_ids}
 
 
-@ cmd.group(help='Manage GitHub account to set reviewers.')
+@cmd.group(help='Manage GitHub account to set reviewers.')
 def account() -> None:
     pass
 
 
-@ account.command(name='list', help='List GitHub account under managements.')
+@account.command(name='list', help='List GitHub account under managements.')
 def _list() -> None:
     """管理下にある GitHub アカウントの一覧を出力する。
     """
     Accounts().dump_list()
 
 
-@ account.command(help='Add GitHub account under managements.')
-@ click.argument('account_id', type=str)
-@ click.option('--display-name', type=str, help='Display name for this user.', required=True)
+@account.command(help='Add GitHub account under managements.')
+@click.argument('account_id', type=str)
+@click.option('--display-name', type=str, help='Display name for this user.', required=True)
 def add(account_id: str, display_name: str) -> None:
     """GitHub アカウントをツールの管理下に登録する。
 
@@ -180,8 +180,8 @@ def add(account_id: str, display_name: str) -> None:
     ]))
 
 
-@ account.command(help='Drop GitHub account under managements.')
-@ click.argument('account_id', type=str)
+@account.command(help='Drop GitHub account under managements.')
+@click.argument('account_id', type=str)
 def drop(account_id: str) -> None:
     """ツール管理下にある GitHub アカウントを管理から外す。
 


### PR DESCRIPTION
<!-- ↓↓↓ develop ➔ main への PR 作成時には削除 ↓↓↓ -->

## チェックリスト

- [x] : Files Changed を確認したか
- [x] : 動作検証を行ったか

---

## Issue 番号

Issue #39 

<!-- ↑↑↑ develop ➔ main への PR 作成時には削除 ↑↑↑ -->

## 変更内容

- レビュアーを指定するプロンプトの表示を、アカウントが存在する場合にのみ行われるよう修正

## 変更理由

- GitHub アカウントが登録されていない場合、`init` コマンドが失敗するため

## 動作検証

済

## 特記事項
