### PR TITLE
docs: modify set up manual and typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Features
 
 * add `update` command ([#47](https://github.com/nkomiya/create-github-project/issues/47)) ([4d7d3cb](https://github.com/nkomiya/create-github-project/commit/4d7d3cb902fce9471d8d403254b45e7915e4ff82))
-* add `version` commad ([#49](https://github.com/nkomiya/create-github-project/issues/49)) ([52e19d2](https://github.com/nkomiya/create-github-project/commit/52e19d240a1e2369a21a57e279a92b4448adb625))
+* add `version` command ([#49](https://github.com/nkomiya/create-github-project/issues/49)) ([52e19d2](https://github.com/nkomiya/create-github-project/commit/52e19d240a1e2369a21a57e279a92b4448adb625))
 
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 ## 前提条件
 
 - Python 3.7 以降がインストールされていること
+- 補完を有効にする場合
+    - Bash shell を利用する場合は、Bash のバージョンが 4.4 以降であること
 
 ## セットアップ手順
 
@@ -18,24 +20,44 @@ python -m venv ${INSTALL_DIR}
 
 ### 2. インストールと設定
 
-- install
+#### インストール
+
+```bash
+${INSTALL_DIR}/bin/python -m pip install -U pip
+${INSTALL_DIR}/bin/python -m pip install -U git+https://github.com/nkomiya/create-github-project@v0.2.0
+```
+
+#### コマンドの設定
+
+1. 環境変数 PATH に含まれるディレクトリに Symbolic link を作成
 
     ```bash
-    ${INSTALL_DIR}/bin/python -m pip install -U pip
-    ${INSTALL_DIR}/bin/python -m pip install -U git+https://github.com/nkomiya/create-github-project@v0.3.0
+    ln -s ${INSTALL_DIR}/bin/create-github-project <Symbolic link 作成先>
     ```
 
-- エイリアスと補完
+1. 補完の有効化
 
-    ```bash
-    alias create-github-project="${INSTALL_DIR}/bin/create-github-project"
+    - **bash** : ~/.bashrc に下記を追記
 
-    # 補完 (bash shell)
-    eval "$(
-        LC_ALL='en_US.UTF8' _CREATE_GITHUB_PROJECT_COMPLETE=bash_source create-github-project |
-        sed -e "s|\$1|${INSTALL_DIR}/bin/create-github-project|"
-    )"
-    ```
+        ```bash
+        eval "$(LC_MESSAGES='en_US.UTF-8' _CREATE_GITHUB_PROJECT_COMPLETE=bash_source create-github-project)"
+        ```
+
+    - **zsh** : ~/.zshrc に下記を追記
+
+        ```shell
+        # 「command not found: compdef」のエラーが出る場合は、下記の設定も必要
+        # autoload -Uz compinit
+        # compinit
+
+        eval "$(_CREATE_GITHUB_PROJECT_COMPLETE=zsh_source create-github-project)"
+        ```
+
+    - **fish** : ~/.config/fish/completions/create-github-project.fish に下記を追記
+
+        ```shell
+        eval (env _CREATE_GITHUB_PROJECT_COMPLETE=fish_source create-github-project)
+        ```
 
 ## 使用方法
 


### PR DESCRIPTION
## Issue 番号

Issue #59, #63 

## 変更内容

- インストール手順を修正
- CHANGELOG の typo を修正

## 変更理由

zsh / fish シェルに対応するため。
