### PR TITLE
chore: fix workflow for patch release

### DIFF
--- a/.github/workflows/patch-release-request.yml
+++ b/.github/workflows/patch-release-request.yml
@@ -38,7 +38,7 @@ jobs:
       - name: set pull request body
         run: |
           body=$(sed -e 's/^#\(#*\) \[/#\1 /' \
-                     -e '1,/^### 0.3.1/d' \
+                     -e '1,/^## ${{steps.set_version.outputs.version}}/d' \
                      -e '/^##* [0-9]/,$d' \
                      CHANGELOG.md)
           echo 'BODY<<EOF' >> $GITHUB_ENV


### PR DESCRIPTION
バージョンがハードコードになっていた。
